### PR TITLE
fix: namespace not specified

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 33
+    namespace 'com.geetest.captcha.flutter.gt4_flutter_plugin'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
从 Android Gradle 插件（AGP） 7.0.0 开始，AGP要求在每个模块的 `build.gradle` 文件中明确定义 `namespace` 以代替之前在 `AndroidManifest.xml` 中定义的 `package` 属性

Starting with Android Gradle Plugin (AGP) 7.0.0, AGP requires that `namespace` be explicitly defined in each module's `build.gradle` file in place of the `package` attribute previously defined in `AndroidManifest.xml`